### PR TITLE
Improve mappedmembers efficiency

### DIFF
--- a/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
@@ -65,6 +65,31 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void CanAddOrReplaceNewProperty()
+        {
+            var property1 = new PropertyMapping();
+            property1.Set(x => x.Name, Layer.Defaults, "Property1");
+            mapping.AddOrReplaceProperty(property1);
+
+            mapping.Properties.ShouldContain(property => ReferenceEquals(property, property1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingProperty()
+        {
+            var property1 = new PropertyMapping();
+            property1.Set(x => x.Name, Layer.Defaults, "Property1");
+            mapping.AddOrReplaceProperty(property1);
+
+            var property2 = new PropertyMapping();
+            property2.Set(x => x.Name, Layer.Defaults, property1.Name);
+            mapping.AddOrReplaceProperty(property2);
+
+            mapping.Properties.ShouldNotContain(property => ReferenceEquals(property, property1));
+            mapping.Properties.ShouldContain(property => ReferenceEquals(property, property2));
+        }
+
+        [Test]
         public void CanAddReference()
         {
             var reference = new ManyToOneMapping();
@@ -87,6 +112,31 @@ namespace FluentNHibernate.Testing.MappingModel
 
             mapping.References.ShouldContain(reference => ReferenceEquals(reference, reference1));
             mapping.References.ShouldNotContain(reference => ReferenceEquals(reference, reference2));
+        }
+
+        [Test]
+        public void CanAddOrReplaceNewReference()
+        {
+            var reference1 = new ManyToOneMapping();
+            reference1.Set(x => x.Name, Layer.Defaults, "Reference1");
+            mapping.AddOrReplaceReference(reference1);
+
+            mapping.References.ShouldContain(reference => ReferenceEquals(reference, reference1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingReference()
+        {
+            var reference1 = new ManyToOneMapping();
+            reference1.Set(x => x.Name, Layer.Defaults, "Reference1");
+            mapping.AddOrReplaceReference(reference1);
+
+            var reference2 = new ManyToOneMapping();
+            reference2.Set(x => x.Name, Layer.Defaults, reference1.Name);
+            mapping.AddOrReplaceReference(reference2);
+
+            mapping.References.ShouldNotContain(reference => ReferenceEquals(reference, reference1));
+            mapping.References.ShouldContain(reference => ReferenceEquals(reference, reference2));
         }
 
         [Test]
@@ -231,6 +281,31 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void CanAddOrReplaceNewCollection()
+        {
+            var collection1 = CollectionMapping.Bag();
+            collection1.Set(x => x.Name, Layer.Defaults, "Collection1");
+            mapping.AddOrReplaceCollection(collection1);
+
+            mapping.Collections.ShouldContain(collection => ReferenceEquals(collection, collection1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingCollection()
+        {
+            var collection1 = CollectionMapping.Bag();
+            collection1.Set(x => x.Name, Layer.Defaults, "Collection1");
+            mapping.AddOrReplaceCollection(collection1);
+
+            var collection2 = CollectionMapping.Bag();
+            collection2.Set(x => x.Name, Layer.Defaults, collection1.Name);
+            mapping.AddOrReplaceCollection(collection2);
+
+            mapping.Collections.ShouldNotContain(collection => ReferenceEquals(collection, collection1));
+            mapping.Collections.ShouldContain(collection => ReferenceEquals(collection, collection2));
+        }
+
+        [Test]
         public void CanAddComponent()
         {
             var component = new ComponentMapping(ComponentType.Component);
@@ -253,6 +328,31 @@ namespace FluentNHibernate.Testing.MappingModel
 
             mapping.Components.ShouldContain(component => ReferenceEquals(component, component1));
             mapping.Components.ShouldNotContain(component => ReferenceEquals(component, component2));
+        }
+
+        [Test]
+        public void CanAddOrReplaceNewComponent()
+        {
+            var component1 = new ComponentMapping(ComponentType.Component);
+            component1.Set(x => x.Name, Layer.Defaults, "Component1");
+            mapping.AddOrReplaceComponent(component1);
+
+            mapping.Components.ShouldContain(component => ReferenceEquals(component, component1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingComponent()
+        {
+            var component1 = new ComponentMapping(ComponentType.Component);
+            component1.Set(x => x.Name, Layer.Defaults, "Component1");
+            mapping.AddOrReplaceComponent(component1);
+
+            var component2 = new ComponentMapping(ComponentType.Component);
+            component2.Set(x => x.Name, Layer.Defaults, component1.Name);
+            mapping.AddOrReplaceComponent(component2);
+
+            mapping.Components.ShouldNotContain(component => ReferenceEquals(component, component1));
+            mapping.Components.ShouldContain(component => ReferenceEquals(component, component2));
         }
 
         [Test]
@@ -281,6 +381,31 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void CanAddOrReplaceNewOneToOne()
+        {
+            var oneToOne1 = new OneToOneMapping();
+            oneToOne1.Set(x => x.Name, Layer.Defaults, "OneToOne1");
+            mapping.AddOrReplaceOneToOne(oneToOne1);
+
+            mapping.OneToOnes.ShouldContain(oneToOne => ReferenceEquals(oneToOne, oneToOne1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingOneToOne()
+        {
+            var oneToOne1 = new OneToOneMapping();
+            oneToOne1.Set(x => x.Name, Layer.Defaults, "OneToOne1");
+            mapping.AddOrReplaceOneToOne(oneToOne1);
+
+            var oneToOne2 = new OneToOneMapping();
+            oneToOne2.Set(x => x.Name, Layer.Defaults, oneToOne1.Name);
+            mapping.AddOrReplaceOneToOne(oneToOne2);
+
+            mapping.OneToOnes.ShouldNotContain(oneToOne => ReferenceEquals(oneToOne, oneToOne1));
+            mapping.OneToOnes.ShouldContain(oneToOne => ReferenceEquals(oneToOne, oneToOne2));
+        }
+
+        [Test]
         public void CanAddAny()
         {
             var any = new AnyMapping();
@@ -303,6 +428,31 @@ namespace FluentNHibernate.Testing.MappingModel
 
             mapping.Anys.ShouldContain(any => ReferenceEquals(any, any1));
             mapping.Anys.ShouldNotContain(any => ReferenceEquals(any, any2));
+        }
+
+        [Test]
+        public void CanAddOrReplaceNewAny()
+        {
+            var any1 = new AnyMapping();
+            any1.Set(x => x.Name, Layer.Defaults, "Any1");
+            mapping.AddOrReplaceAny(any1);
+
+            mapping.Anys.ShouldContain(any => ReferenceEquals(any, any1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingAny()
+        {
+            var any1 = new AnyMapping();
+            any1.Set(x => x.Name, Layer.Defaults, "Any1");
+            mapping.AddOrReplaceAny(any1);
+
+            var any2 = new AnyMapping();
+            any2.Set(x => x.Name, Layer.Defaults, any1.Name);
+            mapping.AddOrReplaceAny(any2);
+
+            mapping.Anys.ShouldNotContain(any => ReferenceEquals(any, any1));
+            mapping.Anys.ShouldContain(any => ReferenceEquals(any, any2));
         }
 
         [Test]
@@ -331,6 +481,31 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void CanAddOrReplaceNewJoin()
+        {
+            var join1 = new JoinMapping();
+            join1.Set(x => x.TableName, Layer.Defaults, "Join1");
+            mapping.AddOrReplaceJoin(join1);
+
+            mapping.Joins.ShouldContain(join => ReferenceEquals(join, join1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingJoin()
+        {
+            var join1 = new JoinMapping();
+            join1.Set(x => x.TableName, Layer.Defaults, "Join1");
+            mapping.AddOrReplaceJoin(join1);
+
+            var join2 = new JoinMapping();
+            join2.Set(x => x.TableName, Layer.Defaults, join1.TableName);
+            mapping.AddOrReplaceJoin(join2);
+
+            mapping.Joins.ShouldNotContain(join => ReferenceEquals(join, join1));
+            mapping.Joins.ShouldContain(join => ReferenceEquals(join, join2));
+        }
+
+        [Test]
         public void CanAddFilter()
         {
             var filter = new FilterMapping();
@@ -353,6 +528,31 @@ namespace FluentNHibernate.Testing.MappingModel
 
             mapping.Filters.ShouldContain(filter => ReferenceEquals(filter, filter1));
             mapping.Filters.ShouldNotContain(filter => ReferenceEquals(filter, filter2));
+        }
+
+        [Test]
+        public void CanAddOrReplaceNewFilter()
+        {
+            var filter1 = new FilterMapping();
+            filter1.Set(x => x.Name, Layer.Defaults, "Filter1");
+            mapping.AddOrReplaceFilter(filter1);
+
+            mapping.Filters.ShouldContain(filter => ReferenceEquals(filter, filter1));
+        }
+
+        [Test]
+        public void CanAddOrReplaceExistingFilter()
+        {
+            var filter1 = new FilterMapping();
+            filter1.Set(x => x.Name, Layer.Defaults, "Filter1");
+            mapping.AddOrReplaceFilter(filter1);
+
+            var filter2 = new FilterMapping();
+            filter2.Set(x => x.Name, Layer.Defaults, filter1.Name);
+            mapping.AddOrReplaceFilter(filter2);
+
+            mapping.Filters.ShouldNotContain(filter => ReferenceEquals(filter, filter1));
+            mapping.Filters.ShouldContain(filter => ReferenceEquals(filter, filter2));
         }
     }
 }

--- a/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
@@ -59,7 +59,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var property2 = new PropertyMapping();
             property2.Set(x => x.Name, Layer.Defaults, property1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddProperty(property2));
-            mapping.Properties.ShouldContain(property1);
+
+            mapping.Properties.ShouldContain(property => ReferenceEquals(property, property1));
+            mapping.Properties.ShouldNotContain(property => ReferenceEquals(property, property2));
         }
 
         [Test]
@@ -82,7 +84,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var reference2 = new ManyToOneMapping();
             reference2.Set(x => x.Name, Layer.Defaults, reference1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddReference(reference2));
-            mapping.References.ShouldContain(reference1);
+
+            mapping.References.ShouldContain(reference => ReferenceEquals(reference, reference1));
+            mapping.References.ShouldNotContain(reference => ReferenceEquals(reference, reference2));
         }
 
         [Test]
@@ -169,8 +173,8 @@ namespace FluentNHibernate.Testing.MappingModel
             mapping.AddStoredProcedure(storedProcedure2);
 
             // Now check that both are present in stored procedures tracker
-            mapping.StoredProcedures.ShouldContain(storedProcedure1);
-            mapping.StoredProcedures.ShouldContain(storedProcedure2);
+            mapping.StoredProcedures.ShouldContain(storedProcedure => ReferenceEquals(storedProcedure, storedProcedure1));
+            mapping.StoredProcedures.ShouldContain(storedProcedure => ReferenceEquals(storedProcedure, storedProcedure2));
         }
 
         [Test]
@@ -221,7 +225,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var collection2 = CollectionMapping.Bag();
             collection2.Set(x => x.Name, Layer.Defaults, collection1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddCollection(collection2));
-            mapping.Collections.ShouldContain(collection1);
+
+            mapping.Collections.ShouldContain(collection => ReferenceEquals(collection, collection1));
+            mapping.Collections.ShouldNotContain(collection => ReferenceEquals(collection, collection2));
         }
 
         [Test]
@@ -244,7 +250,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var component2 = new ComponentMapping(ComponentType.Component);
             component2.Set(x => x.Name, Layer.Defaults, component1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddComponent(component2));
-            mapping.Components.ShouldContain(component1);
+
+            mapping.Components.ShouldContain(component => ReferenceEquals(component, component1));
+            mapping.Components.ShouldNotContain(component => ReferenceEquals(component, component2));
         }
 
         [Test]
@@ -267,7 +275,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var oneToOne2 = new OneToOneMapping();
             oneToOne2.Set(x => x.Name, Layer.Defaults, oneToOne1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddOneToOne(oneToOne2));
-            mapping.OneToOnes.ShouldContain(oneToOne1);
+
+            mapping.OneToOnes.ShouldContain(oneToOne => ReferenceEquals(oneToOne, oneToOne1));
+            mapping.OneToOnes.ShouldNotContain(oneToOne => ReferenceEquals(oneToOne, oneToOne2));
         }
 
         [Test]
@@ -290,7 +300,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var any2 = new AnyMapping();
             any2.Set(x => x.Name, Layer.Defaults, any1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddAny(any2));
-            mapping.Anys.ShouldContain(any1);
+
+            mapping.Anys.ShouldContain(any => ReferenceEquals(any, any1));
+            mapping.Anys.ShouldNotContain(any => ReferenceEquals(any, any2));
         }
 
         [Test]
@@ -313,7 +325,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var join2 = new JoinMapping();
             join2.Set(x => x.TableName, Layer.Defaults, join1.TableName);
             Assert.Throws<InvalidOperationException>(() => mapping.AddJoin(join2));
-            mapping.Joins.ShouldContain(join1);
+
+            mapping.Joins.ShouldContain(join => ReferenceEquals(join, join1));
+            mapping.Joins.ShouldNotContain(join => ReferenceEquals(join, join2));
         }
 
         [Test]
@@ -336,7 +350,9 @@ namespace FluentNHibernate.Testing.MappingModel
             var filter2 = new FilterMapping();
             filter2.Set(x => x.Name, Layer.Defaults, filter1.Name);
             Assert.Throws<InvalidOperationException>(() => mapping.AddFilter(filter2));
-            mapping.Filters.ShouldContain(filter1);
+
+            mapping.Filters.ShouldContain(filter => ReferenceEquals(filter, filter1));
+            mapping.Filters.ShouldNotContain(filter => ReferenceEquals(filter, filter2));
         }
     }
 }

--- a/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
@@ -4,6 +4,7 @@ using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.MappingModel.Identity;
 using FluentNHibernate.Visitors;
 using FakeItEasy;
+using FluentNHibernate.MappingModel.Collections;
 using NUnit.Framework;
 
 namespace FluentNHibernate.Testing.MappingModel
@@ -148,6 +149,66 @@ namespace FluentNHibernate.Testing.MappingModel
             classMap.AcceptVisitor(visitor);
 
             A.CallTo(() => visitor.Visit(classMap.Discriminator)).MustHaveHappened();
+        }
+
+        [Test]
+        public void CanAddCollection()
+        {
+            var collection = CollectionMapping.Bag();
+            collection.Set(x => x.Name, Layer.Defaults, "Collection1");
+            mapping.AddCollection(collection);
+
+            mapping.Collections.ShouldContain(collection);
+        }
+
+        [Test]
+        public void CanAddComponent()
+        {
+            var component = new ComponentMapping(ComponentType.Component);
+            component.Set(x => x.Name, Layer.Defaults, "Component1");
+            mapping.AddComponent(component);
+
+            mapping.Components.ShouldContain(component);
+        }
+
+        [Test]
+        public void CanAddOneToOne()
+        {
+            var oneToOne = new OneToOneMapping();
+            oneToOne.Set(x => x.Name, Layer.Defaults, "OneToOne1");
+            mapping.AddOneToOne(oneToOne);
+
+            mapping.OneToOnes.ShouldContain(oneToOne);
+        }
+
+        [Test]
+        public void CanAddAny()
+        {
+            var any = new AnyMapping();
+            any.Set(x => x.Name, Layer.Defaults, "Any1");
+            mapping.AddAny(any);
+
+            mapping.Anys.ShouldContain(any);
+        }
+
+        [Test]
+        public void CanAddJoin()
+        {
+            var join = new JoinMapping();
+            join.Set(x => x.TableName, Layer.Defaults, "TableName1");
+            mapping.AddJoin(join);
+
+            mapping.Joins.ShouldContain(join);
+        }
+
+        [Test]
+        public void CanAddFilter()
+        {
+            var filter = new FilterMapping();
+            filter.Set(x => x.Name, Layer.Defaults, "Filter1");
+            mapping.AddFilter(filter);
+
+            mapping.Filters.ShouldContain(filter);
         }
     }
 }

--- a/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using FluentNHibernate.MappingModel;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.MappingModel.Identity;
@@ -49,6 +50,19 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void ShouldFailToAddDuplicateProperty()
+        {
+            var property1 = new PropertyMapping();
+            property1.Set(x => x.Name, Layer.Defaults, "Property1");
+            mapping.AddProperty(property1);
+
+            var property2 = new PropertyMapping();
+            property2.Set(x => x.Name, Layer.Defaults, property1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddProperty(property2));
+            mapping.Properties.ShouldContain(property1);
+        }
+
+        [Test]
         public void CanAddReference()
         {
             var reference = new ManyToOneMapping();
@@ -56,6 +70,19 @@ namespace FluentNHibernate.Testing.MappingModel
             mapping.AddReference(reference);
 
             mapping.References.ShouldContain(reference);
+        }
+
+        [Test]
+        public void ShouldFailToAddDuplicateReference()
+        {
+            var reference1 = new ManyToOneMapping();
+            reference1.Set(x => x.Name, Layer.Defaults, "parent");
+            mapping.AddReference(reference1);
+
+            var reference2 = new ManyToOneMapping();
+            reference2.Set(x => x.Name, Layer.Defaults, reference1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddReference(reference2));
+            mapping.References.ShouldContain(reference1);
         }
 
         [Test]
@@ -89,10 +116,10 @@ namespace FluentNHibernate.Testing.MappingModel
         [Test]
         public void CanAddSubclass()
         {
-            var joinedSubclass = new SubclassMapping(SubclassType.JoinedSubclass);
-            mapping.AddSubclass(joinedSubclass);
+            var subclass = new SubclassMapping(SubclassType.JoinedSubclass);
+            mapping.AddSubclass(subclass);
 
-            mapping.Subclasses.ShouldContain(joinedSubclass);
+            mapping.Subclasses.ShouldContain(subclass);
         }
 
         [Test]
@@ -121,6 +148,29 @@ namespace FluentNHibernate.Testing.MappingModel
             mapping.AddStoredProcedure(storedProcedure);
 
             mapping.StoredProcedures.ShouldContain(storedProcedure);
+        }
+
+        [Test]
+        public void CanAddDuplicateStoredProcedure()
+        {
+            // Unlike other types, stored procedures do allow duplicate entries. However, in order to distinguish
+            // whether two entries are identical or not, we need to set some non-identity attribute on them to be
+            // a different value. For this test, "Query" is easy enough.
+            var storedProcedure1 = new StoredProcedureMapping();
+            storedProcedure1.Set(x => x.Name, Layer.Defaults, "storedProcedure1");
+            storedProcedure1.Set(x => x.Query, Layer.Defaults, "x=y");
+            mapping.AddStoredProcedure(storedProcedure1);
+
+            var storedProcedure2 = new StoredProcedureMapping();
+            storedProcedure1.Set(x => x.Name, Layer.Defaults, storedProcedure1.Name);
+            storedProcedure1.Set(x => x.Query, Layer.Defaults, "x=y");
+
+            // Check that adding the duplicate does _not_ throw
+            mapping.AddStoredProcedure(storedProcedure2);
+
+            // Now check that both are present in stored procedures tracker
+            mapping.StoredProcedures.ShouldContain(storedProcedure1);
+            mapping.StoredProcedures.ShouldContain(storedProcedure2);
         }
 
         [Test]
@@ -162,6 +212,19 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void ShouldFailToAddDuplicateCollection()
+        {
+            var collection1 = CollectionMapping.Bag();
+            collection1.Set(x => x.Name, Layer.Defaults, "Collection1");
+            mapping.AddCollection(collection1);
+
+            var collection2 = CollectionMapping.Bag();
+            collection2.Set(x => x.Name, Layer.Defaults, collection1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddCollection(collection2));
+            mapping.Collections.ShouldContain(collection1);
+        }
+
+        [Test]
         public void CanAddComponent()
         {
             var component = new ComponentMapping(ComponentType.Component);
@@ -169,6 +232,19 @@ namespace FluentNHibernate.Testing.MappingModel
             mapping.AddComponent(component);
 
             mapping.Components.ShouldContain(component);
+        }
+
+        [Test]
+        public void ShouldFailToAddDuplicateComponent()
+        {
+            var component1 = new ComponentMapping(ComponentType.Component);
+            component1.Set(x => x.Name, Layer.Defaults, "Component1");
+            mapping.AddComponent(component1);
+
+            var component2 = new ComponentMapping(ComponentType.Component);
+            component2.Set(x => x.Name, Layer.Defaults, component1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddComponent(component2));
+            mapping.Components.ShouldContain(component1);
         }
 
         [Test]
@@ -182,6 +258,19 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void ShouldFailToAddDuplicateOneToOne()
+        {
+            var oneToOne1 = new OneToOneMapping();
+            oneToOne1.Set(x => x.Name, Layer.Defaults, "OneToOne1");
+            mapping.AddOneToOne(oneToOne1);
+
+            var oneToOne2 = new OneToOneMapping();
+            oneToOne2.Set(x => x.Name, Layer.Defaults, oneToOne1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddOneToOne(oneToOne2));
+            mapping.OneToOnes.ShouldContain(oneToOne1);
+        }
+
+        [Test]
         public void CanAddAny()
         {
             var any = new AnyMapping();
@@ -189,6 +278,19 @@ namespace FluentNHibernate.Testing.MappingModel
             mapping.AddAny(any);
 
             mapping.Anys.ShouldContain(any);
+        }
+
+        [Test]
+        public void ShouldFailToAddDuplicateAny()
+        {
+            var any1 = new AnyMapping();
+            any1.Set(x => x.Name, Layer.Defaults, "Any1");
+            mapping.AddAny(any1);
+
+            var any2 = new AnyMapping();
+            any2.Set(x => x.Name, Layer.Defaults, any1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddAny(any2));
+            mapping.Anys.ShouldContain(any1);
         }
 
         [Test]
@@ -202,6 +304,19 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
+        public void ShouldFailToAddDuplicateJoin()
+        {
+            var join1 = new JoinMapping();
+            join1.Set(x => x.TableName, Layer.Defaults, "TableName1");
+            mapping.AddJoin(join1);
+
+            var join2 = new JoinMapping();
+            join2.Set(x => x.TableName, Layer.Defaults, join1.TableName);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddJoin(join2));
+            mapping.Joins.ShouldContain(join1);
+        }
+
+        [Test]
         public void CanAddFilter()
         {
             var filter = new FilterMapping();
@@ -209,6 +324,19 @@ namespace FluentNHibernate.Testing.MappingModel
             mapping.AddFilter(filter);
 
             mapping.Filters.ShouldContain(filter);
+        }
+
+        [Test]
+        public void ShouldFailToAddDuplicateFilter()
+        {
+            var filter1 = new FilterMapping();
+            filter1.Set(x => x.Name, Layer.Defaults, "Filter1");
+            mapping.AddFilter(filter1);
+
+            var filter2 = new FilterMapping();
+            filter2.Set(x => x.Name, Layer.Defaults, filter1.Name);
+            Assert.Throws<InvalidOperationException>(() => mapping.AddFilter(filter2));
+            mapping.Filters.ShouldContain(filter1);
         }
     }
 }

--- a/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
+++ b/src/FluentNHibernate.Testing/MappingModel/ClassMappingTester.cs
@@ -86,10 +86,11 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
-        public void Can_add_subclass()
+        public void CanAddSubclass()
         {
             var joinedSubclass = new SubclassMapping(SubclassType.JoinedSubclass);
             mapping.AddSubclass(joinedSubclass);
+
             mapping.Subclasses.ShouldContain(joinedSubclass);
         }
 
@@ -113,10 +114,11 @@ namespace FluentNHibernate.Testing.MappingModel
         }
 
         [Test]
-        public void Can_add_stored_procedure()
+        public void CanAddStoredProcedure()
         {
             var storedProcedure = new StoredProcedureMapping();
             mapping.AddStoredProcedure(storedProcedure);
+
             mapping.StoredProcedures.ShouldContain(storedProcedure);
         }
 

--- a/src/FluentNHibernate/MappingModel/MappedMembers.cs
+++ b/src/FluentNHibernate/MappingModel/MappedMembers.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentNHibernate.MappingModel.ClassBased;
 using FluentNHibernate.Visitors;
+using NHibernate.Util;
 
 namespace FluentNHibernate.MappingModel
 {
@@ -22,10 +23,14 @@ namespace FluentNHibernate.MappingModel
         }
 
         private readonly List<Tuple<MappingType, IMapping>> orderedMappings;
+        private readonly IReadOnlyDictionary<MappingType, IDictionary<string, int>> mappingIndicesByType;
 
         public MappedMembers()
         {
             orderedMappings = new List<Tuple<MappingType, IMapping>>();
+            // This has to use a NullableDictionary or (at least) various test cases will fail due to null names on mappings
+            IDictionary<string, int> IndexMapGen(MappingType ignored) => new NullableDictionary<string, int>();
+            mappingIndicesByType = Enum.GetValues(typeof(MappingType)).Cast<MappingType>().ToDictionary(m => m, IndexMapGen);
         }
 
         public IEnumerable<PropertyMapping> Properties => orderedMappings.Where(x => x.Item1 == MappingType.Property).Select(x => x.Item2).Cast<PropertyMapping>();
@@ -48,99 +53,90 @@ namespace FluentNHibernate.MappingModel
 
         public void AddOrReplaceFilter(FilterMapping mapping)
         {
-            AddOrReplaceMapping(mapping, MappingType.Filter, x => x.Name == mapping.Name);
+            AddOrReplaceMapping(mapping, MappingType.Filter, x => x.Name);
         }
 
         public void AddProperty(PropertyMapping property)
         {
-            string propertyName = property.Name;
-            if (Properties.Any(x => x.Name == propertyName))
-                throw new InvalidOperationException("Tried to add property '" + propertyName + "' when already added.");
-            AddMapping(property, MappingType.Property);
+            AddMapping(property, MappingType.Property, x => x.Name,
+                "Tried to add property '" + property.Name + "' when already added.");
         }
 
         public void AddOrReplaceProperty(PropertyMapping mapping)
         {
-            AddOrReplaceMapping(mapping, MappingType.Property, x => x.Name == mapping.Name);
+            AddOrReplaceMapping(mapping, MappingType.Property, x => x.Name);
         }
 
         public void AddCollection(Collections.CollectionMapping collection)
         {
-            if (Collections.Any(x => x.Name == collection.Name))
-                throw new InvalidOperationException("Tried to add collection '" + collection.Name + "' when already added.");
-            AddMapping(collection, MappingType.Collection);
+            AddMapping(collection, MappingType.Collection, x => x.Name,
+                "Tried to add collection '" + collection.Name + "' when already added.");
         }
 
         public void AddOrReplaceCollection(Collections.CollectionMapping mapping)
         {
-            AddOrReplaceMapping(mapping, MappingType.Collection, x => x.Name == mapping.Name);
+            AddOrReplaceMapping(mapping, MappingType.Collection, x => x.Name);
         }
 
         public void AddReference(ManyToOneMapping manyToOne)
         {
-            if (References.Any(x => x.Name == manyToOne.Name))
-                throw new InvalidOperationException("Tried to add many-to-one '" + manyToOne.Name + "' when already added.");
-            AddMapping(manyToOne, MappingType.ManyToOne);
+            AddMapping(manyToOne, MappingType.ManyToOne, x => x.Name,
+                "Tried to add many-to-one '" + manyToOne.Name + "' when already added.");
         }
 
         public void AddOrReplaceReference(ManyToOneMapping manyToOne)
         {
-            AddOrReplaceMapping(manyToOne, MappingType.ManyToOne, x => x.Name == manyToOne.Name);
+            AddOrReplaceMapping(manyToOne, MappingType.ManyToOne, x => x.Name);
         }
 
         public void AddComponent(IComponentMapping componentMapping)
         {
-            if (Components.Any(x => x.Name == componentMapping.Name))
-                throw new InvalidOperationException("Tried to add component '" + componentMapping.Name + "' when already added.");
-            AddMapping(componentMapping, MappingType.IComponent);
+            AddMapping(componentMapping, MappingType.IComponent, x => x.Name,
+                "Tried to add component '" + componentMapping.Name + "' when already added.");
         }
 
         public void AddOrReplaceComponent(IComponentMapping componentMapping)
         {
-            AddOrReplaceMapping(componentMapping, MappingType.IComponent, x => x.Name == componentMapping.Name);
+            AddOrReplaceMapping(componentMapping, MappingType.IComponent, x => x.Name);
         }
 
         public void AddOneToOne(OneToOneMapping mapping)
         {
-            if (OneToOnes.Any(x => x.Name == mapping.Name))
-                throw new InvalidOperationException("Tried to add one-to-one '" + mapping.Name + "' when already added.");
-            AddMapping(mapping, MappingType.OneToOne);
+            AddMapping(mapping, MappingType.OneToOne, x => x.Name,
+                "Tried to add one-to-one '" + mapping.Name + "' when already added.");
         }
 
         public void AddOrReplaceOneToOne(OneToOneMapping mapping)
         {
-            AddOrReplaceMapping(mapping, MappingType.OneToOne, x => x.Name == mapping.Name);
+            AddOrReplaceMapping(mapping, MappingType.OneToOne, x => x.Name);
         }
 
         public void AddAny(AnyMapping mapping)
         {
-            if (Anys.Any(x => x.Name == mapping.Name))
-                throw new InvalidOperationException("Tried to add any '" + mapping.Name + "' when already added.");
-            AddMapping(mapping, MappingType.Any);
+            AddMapping(mapping, MappingType.Any, x => x.Name,
+                "Tried to add any '" + mapping.Name + "' when already added.");
         }
 
         public void AddOrReplaceAny(AnyMapping mapping)
         {
-            AddOrReplaceMapping(mapping, MappingType.Any, x => x.Name == mapping.Name);
+            AddOrReplaceMapping(mapping, MappingType.Any, x => x.Name);
         }
 
         public void AddJoin(JoinMapping mapping)
         {
-            if (Joins.Any(x => x.TableName == mapping.TableName))
-                throw new InvalidOperationException("Tried to add join to table '" + mapping.TableName + "' when already added.");
-            AddMapping(mapping, MappingType.Join);
+            AddMapping(mapping, MappingType.Join, x => x.TableName,
+                "Tried to add join to table '" + mapping.TableName + "' when already added.");
         }
 
         public void AddOrReplaceJoin(JoinMapping mapping)
         {
-            AddOrReplaceMapping(mapping, MappingType.Join, x => x.TableName == mapping.TableName);
+            AddOrReplaceMapping(mapping, MappingType.Join, x => x.TableName);
         }
 
         public void AddFilter(FilterMapping mapping)
         {
-            if (Filters.Any(x => x.Name == mapping.Name))
-                throw new InvalidOperationException("Tried to add filter with name '" + mapping.Name + "' when already added.");
-            AddMapping(mapping, MappingType.Filter);
+            AddMapping(mapping, MappingType.Filter, x => x.Name,
+                "Tried to add filter with name '" + mapping.Name + "' when already added.");
         }
 
         public virtual void AcceptVisitor(IMappingModelVisitor visitor)
@@ -189,7 +185,7 @@ namespace FluentNHibernate.MappingModel
 
         public void AddStoredProcedure(StoredProcedureMapping mapping)
         {
-            AddMapping(mapping, MappingType.StoredProcedure);
+            ManageMapping(mapping, MappingType.StoredProcedure, null, true, false, null);
         }
 
         public bool Equals(MappedMembers other)
@@ -211,19 +207,37 @@ namespace FluentNHibernate.MappingModel
             return orderedMappings.GetHashCode();
         }
 
-        private void AddMapping<TMapping>(TMapping mapping, MappingType mappingType) where TMapping : IMapping {
-            orderedMappings.Add(Tuple.Create(mappingType, (IMapping)mapping));
+        private void AddMapping<TMapping>(TMapping mapping, MappingType mappingType, Func<TMapping, string> keyMapper, string badDupeMsg)
+                where TMapping : IMapping
+        {
+            ManageMapping(mapping, mappingType, keyMapper, false, false, badDupeMsg);
         }
 
-        private void AddOrReplaceMapping<TMapping>(TMapping mapping, MappingType mappingType, Predicate<TMapping> matchPredicate) {
-            var newMapping = Tuple.Create(mappingType, (IMapping)mapping);            
-            var index = orderedMappings.FindIndex(x => x.Item1 == mappingType && matchPredicate((TMapping)x.Item2));
-            if (index >= 0)
-                orderedMappings[index] = newMapping;
-            else
-                orderedMappings.Add(newMapping);
+        private void AddOrReplaceMapping<TMapping>(TMapping mapping, MappingType mappingType, Func<TMapping, string> keyMapper) where TMapping : IMapping
+        {
+            ManageMapping(mapping, mappingType, keyMapper, false, true, null);
         }
 
+        private void ManageMapping<TMapping>(TMapping mapping, MappingType mappingType, Func<TMapping, string> keyMapper, bool allowDupes, bool allowReplace,
+                string badDupeMsg) where TMapping : IMapping
+        {
+            var newTuple = Tuple.Create(mappingType, (IMapping)mapping);
+            if (allowDupes) {
+                orderedMappings.Add(newTuple);
+                // Types that allow duplicates don't have index tracking
+            } else {
+                var key = keyMapper(mapping);
+                var mappingIndices = mappingIndicesByType[mappingType];
+                if (!mappingIndices.ContainsKey(key))
+                {
+                    orderedMappings.Add(newTuple);
+                    mappingIndices[key] = orderedMappings.Count - 1;
+                }
+                else if (allowReplace)
+                        orderedMappings[mappingIndices[key]] = newTuple;
+                else
+                    throw new InvalidOperationException(badDupeMsg);
+            }
+        }
     }
 }
-

--- a/src/FluentNHibernate/MappingModel/MappedMembers.cs
+++ b/src/FluentNHibernate/MappingModel/MappedMembers.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using FluentNHibernate.MappingModel.ClassBased;
-using FluentNHibernate.Utils;
 using FluentNHibernate.Visitors;
 
 namespace FluentNHibernate.MappingModel


### PR DESCRIPTION
Improve the performance of the Add* / AddOrReplace* methods in MappedMembers from O(n) to O(1) by tracking the position index in a dictionary so that existing values can be detected / accessed without having to scan the entire list.

Also expand / add a number of unit tests that cover MappedMember behavior indirectly (through ClassMapping) as part of ensuring that the changes don't break things.
